### PR TITLE
Fix code scanning alert no. 2: Unvalidated dynamic method call

### DIFF
--- a/packages/safe-apps-sdk/dist/esm/communication/index.js
+++ b/packages/safe-apps-sdk/dist/esm/communication/index.js
@@ -28,9 +28,11 @@ class PostMessageCommunicator {
         this.handleIncomingMessage = (payload) => {
             const { id } = payload;
             const cb = this.callbacks.get(id);
-            if (cb) {
+            if (typeof cb === 'function') {
                 cb(payload);
                 this.callbacks.delete(id);
+            } else {
+                console.error(`Callback for id ${id} is not a function or does not exist.`);
             }
         };
         this.send = (method, params) => {


### PR DESCRIPTION
Fixes [https://github.com/Dargon789/safe-apps-sdk/security/code-scanning/2](https://github.com/Dargon789/safe-apps-sdk/security/code-scanning/2)

To fix the problem, we need to ensure that the `cb` retrieved from the `callbacks` map is a function before attempting to call it. This can be done by adding a type check for `cb` before invoking it. If `cb` is not a function, we should handle this case gracefully, possibly by logging an error or ignoring the message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
