### PR TITLE
Fix code scanning alert no. 4: Use of externally-controlled format string

### DIFF
--- a/packages/safe-apps-sdk/dist/cjs/communication/index.js
+++ b/packages/safe-apps-sdk/dist/cjs/communication/index.js
@@ -33,7 +33,7 @@ class PostMessageCommunicator {
             return !emptyOrMalformed && sentFromParentEl && allowedSDKVersion && validOrigin;
         };
         this.logIncomingMessage = (msg) => {
-            console.info(`Safe Apps SDK v1: A message was received from origin ${msg.origin}. `, msg.data);
+            console.info("Safe Apps SDK v1: A message was received from origin %s. ", msg.origin, msg.data);
         };
         this.onParentMessage = (msg) => {
             if (this.isValidMessage(msg)) {


### PR DESCRIPTION
Fixes [https://github.com/Dargon789/safe-apps-sdk/security/code-scanning/4](https://github.com/Dargon789/safe-apps-sdk/security/code-scanning/4)

To fix the problem, we should ensure that the untrusted input (`msg.origin`) is properly handled before being included in the log message. The best way to do this is to use a `%s` specifier in the format string and pass the untrusted data as a corresponding argument. This approach ensures that the untrusted data is treated as a string and not as a format specifier.

- Modify the `console.info` call on line 36 to use a `%s` specifier for `msg.origin`.
- Pass `msg.origin` as an additional argument to the `console.info` function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Ensure untrusted input in log messages is handled safely by using a format specifier.