### PR TITLE
Fix code scanning alert no. 1: Unvalidated dynamic method call

### DIFF
--- a/packages/safe-apps-sdk/dist/cjs/communication/index.js
+++ b/packages/safe-apps-sdk/dist/cjs/communication/index.js
@@ -44,9 +44,11 @@ class PostMessageCommunicator {
         this.handleIncomingMessage = (payload) => {
             const { id } = payload;
             const cb = this.callbacks.get(id);
-            if (cb) {
+            if (typeof cb === 'function') {
                 cb(payload);
                 this.callbacks.delete(id);
+            } else {
+                console.error(`Callback for id ${id} is not a function or does not exist.`);
             }
         };
         this.send = (method, params) => {


### PR DESCRIPTION
Fixes [https://github.com/Dargon789/safe-apps-sdk/security/code-scanning/1](https://github.com/Dargon789/safe-apps-sdk/security/code-scanning/1)

To fix the problem, we need to ensure that the `cb` retrieved from the `callbacks` map is a function before invoking it. This can be done by adding a type check before calling `cb(payload)`. If `cb` is not a function, we should handle the error gracefully, possibly by logging an error message or ignoring the invalid callback.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Add a type check to ensure the callback retrieved from the callbacks map is a function before invoking it, preventing unvalidated dynamic method calls.