### PR TITLE
Potential fix for code scanning alert no. 6: Use of externally-controlled format string

### DIFF
--- a/packages/safe-apps-sdk/src/communication/index.ts
+++ b/packages/safe-apps-sdk/src/communication/index.ts
@@ -34,7 +34,7 @@ class PostMessageCommunicator implements Communicator {
   };
 
   private logIncomingMessage = (msg: InterfaceMessageEvent): void => {
-    console.info(`Safe Apps SDK v1: A message was received from origin ${msg.origin}. `, msg.data);
+    console.info('Safe Apps SDK v1: A message was received from origin %s.', msg.origin, msg.data);
   };
 
   private onParentMessage = (msg: InterfaceMessageEvent): void => {


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/safe-apps-sdk/security/code-scanning/6](https://github.com/Dargon789/safe-apps-sdk/security/code-scanning/6)

To fix the problem, we should ensure that the untrusted data (`msg.origin`) is properly sanitized or passed as a separate argument to the `console.info` function. The best way to fix this without changing the existing functionality is to use a `%s` specifier in the format string and pass `msg.origin` as a corresponding argument. This approach ensures that the untrusted data is treated as a string and does not interfere with the format string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Fixes a potential code scanning alert related to the use of an externally-controlled format string.