### PR TITLE
Potential fix for code scanning alert no. 5: Use of externally-controlled format string

### DIFF
--- a/packages/safe-apps-sdk/dist/esm/communication/index.js
+++ b/packages/safe-apps-sdk/dist/esm/communication/index.js
@@ -17,7 +17,7 @@ class PostMessageCommunicator {
             return !emptyOrMalformed && sentFromParentEl && allowedSDKVersion && validOrigin;
         };
         this.logIncomingMessage = (msg) => {
-            console.info(`Safe Apps SDK v1: A message was received from origin ${msg.origin}. `, msg.data);
+            console.info("Safe Apps SDK v1: A message was received from origin %s. ", msg.origin, msg.data);
         };
         this.onParentMessage = (msg) => {
             if (this.isValidMessage(msg)) {


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/safe-apps-sdk/security/code-scanning/5](https://github.com/Dargon789/safe-apps-sdk/security/code-scanning/5)

To fix the problem, we should ensure that the user-controlled input (`msg.origin`) is properly sanitized before being included in the format string. The best way to fix this issue without changing the existing functionality is to use a `%s` specifier in the format string and pass the `msg.origin` as a corresponding argument to `console.info`. This approach ensures that the user-controlled input is treated as a string and prevents any unintended format specifiers from causing issues.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
