### PR TITLE
chore: pin GitHub Actions to commit SHAs (safe-global#663)

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -12,7 +12,7 @@ jobs:
       - name: 'CLA Assistant'
         if: (github.event.comment.body == 'recheckcla' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
         # Beta Release
-        uses: contributor-assistant/github-action@v2.2.0
+        uses: contributor-assistant/github-action@b2a7f9fb90217ea0b8a0c95c288221457be4a31f # v2.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # the below token should have repo scope and must be manually added by you in the repository's secret

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,10 +5,10 @@ jobs:
   eslint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
       - name: Use Node.js 18
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: 18
           cache: yarn

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,13 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
 
       - name: Setup Node.js 18
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: 18
 
@@ -28,6 +28,6 @@ jobs:
 
       - name: Create Version/Changelogs Pull Request or Create Github Releases
         id: changesets
-        uses: gnosis/changesets-action-github-releases@v1.2.0
+        uses: gnosis/changesets-action-github-releases@0c10ec15081f104b1ce721beadafddb9d2880336 # v1.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,9 +9,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: Use Node.js 18
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: 18
       - run: yarn install --frozen-lockfile

--- a/guides/drain-safe-app/01-bootstrap-the-app.md
+++ b/guides/drain-safe-app/01-bootstrap-the-app.md
@@ -42,7 +42,7 @@ Above is a typical React application structure, so everything should be familiar
 
 # Load the app inside the Safe interface
 
-You can access our testnet deployment at https://app.safe.global/?chain=gor.
+You can load a Safe on any of the testnets available at https://app.safe.global.
 
 First, you need a Safe. Just follow the steps on the welcome page to create one. As soon as it's created, it should take you to a Safe overview page. Next, you need to click on the "Apps" entry in the sidebar on the left.
 

--- a/packages/safe-apps-sdk/README.md
+++ b/packages/safe-apps-sdk/README.md
@@ -54,7 +54,7 @@ type Opts = {
 };
 
 const opts: Opts = {
-  allowedDomains: [/^app\.safe\.global$/],
+  allowedDomains: [/^https:\/\/app\.safe\.global$/],
   debug: false,
 };
 
@@ -139,7 +139,7 @@ Sending a TX through the Safe is as simple as invoking `.txs.send()`
 
 ```js
 // Create a web3 instance
-const web3 = new Web3('https://goerli.infura.io/v3/{YOUR_API_KEY}');
+const web3 = new Web3('https://sepolia.infura.io/v3/{YOUR_API_KEY}');
 const contract = new web3.eth.Contract(abi, contractAddress);
 
 const txs = [
@@ -567,7 +567,7 @@ As in most cases the SSL certificate provided by `react-scripts` is not valid it
 
 ### Loading the Safe App
 
-While developing your Safe App you can directly use [our production interface](https://app.safe.global) for testing it. Some testnets like Goerli are also available there.
+While developing your Safe App you can directly use [our production interface](https://app.safe.global) for testing it. Some testnets like Sepolia are also available there.
 Once your app is live, even if you are running it locally, you can import it to the Safe application as a custom app. To do so, you should select the "Apps" tab:
 
 ![Apps section button][safeappstab]

--- a/packages/safe-apps-wagmi/README.md
+++ b/packages/safe-apps-wagmi/README.md
@@ -24,7 +24,7 @@ const config = createConfig({
     new SafeConnector({
       chains,
       options: {
-        allowedDomains: [/^app\.safe\.global$/],
+        allowedDomains: [/^https:\/\/app\.safe\.global$/],
         debug: false,
       },
     }),


### PR DESCRIPTION
## Summary by Sourcery

Pin GitHub Actions workflows to specific action commit SHAs and refresh Safe Apps documentation examples and references.

Build:
- Pin workflow actions (checkout, setup-node, changesets release action, CLA assistant) to specific commit SHAs for reproducible and secure CI runs.

Documentation:
- Update Safe Apps SDK and wagmi connector docs to require fully qualified https://app.safe.global domains in allowedDomains examples.
- Refresh network references in documentation from Goerli to Sepolia and generalize testnet guidance for loading Safes via the production interface.